### PR TITLE
chore: re-pin btc-rpc-proxy to v0.5.1; → 29.4:7

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Three additional containers are used:
 
 | Container | Image                                     | Purpose                                       |
 | --------- | ----------------------------------------- | --------------------------------------------- |
-| `proxy`   | `ghcr.io/start9labs/btc-rpc-proxy:v0.5.0` | RPC proxy for pruned nodes                    |
+| `proxy`   | `ghcr.io/start9labs/btc-rpc-proxy:v0.5.1` | RPC proxy for pruned nodes                    |
 | `python`  | `python` (Alpine)                         | Runs `rpcauth.py` to generate RPC credentials |
 | `i2pd`    | `purplei2p/i2pd`                          | Embedded I2P daemon (when enabled)            |
 
@@ -101,11 +101,11 @@ Bitcoin Core is configured through **StartOS actions** that write to `bitcoin.co
 
 ### Configuration Actions
 
-| Action               | Settings                                                                                                                                                                     |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Mempool Settings** | persistmempool, maxmempool, mempoolexpiry, permitbaremultisig, OP_RETURN (datacarrier/datacarriersize), minrelaytxfee, bytespersigop, blocksonly                             |
-| **Peer Settings**    | onlynet (ipv4/ipv6/onion/i2p), BIP324 v2transport, I2P SAM proxy (enabled/disabled), connect/addnode peers, maxconnections                                                   |
-| **RPC Settings**     | rpcservertimeout, rpcthreads, rpcworkqueue                                                                                                                                   |
+| Action               | Settings                                                                                                                                                                                                                           |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Mempool Settings** | persistmempool, maxmempool, mempoolexpiry, permitbaremultisig, OP_RETURN (datacarrier/datacarriersize), minrelaytxfee, bytespersigop, blocksonly                                                                                   |
+| **Peer Settings**    | onlynet (ipv4/ipv6/onion/i2p), BIP324 v2transport, I2P SAM proxy (enabled/disabled), connect/addnode peers, maxconnections                                                                                                         |
+| **RPC Settings**     | rpcservertimeout, rpcthreads, rpcworkqueue                                                                                                                                                                                         |
 | **Other Settings**   | ZMQ, txindex, blocknotify, blockreconstructionextratxn, coinstatsindex, wallet settings (enable/avoidpartialspends/discardfee), pruning, dbcache, dbbatchsize, BIP158/BIP157 block filters, bloom filters, natpmp, maxuploadtarget |
 
 Settings **not** managed by StartOS (hardcoded):
@@ -133,6 +133,7 @@ The proxy also serves blocks bitcoind has already pruned. Its config sets `defau
 - Only `getblock` verbosity 0 and 1 are intercepted; verbosity 2 is forwarded unchanged and still fails on a pruned block. It could not be answered faithfully anyway — the per-input `fee` fields need undo data a pruned node no longer has.
 - Peers are dialed directly on clearnet, through `tor_proxy` for `.onion`, and through `i2p_proxy` for `.b32.i2p`. That last one points at i2pd's SOCKS proxy, which `i2pd.conf` enables on loopback by default; when the i2pd daemon isn't running the key is omitted and I2P-only peers are unusable.
 - `max_peer_concurrency` caps how many peers are asked for the same block at once. The first valid answer wins, so leaving it unset pulls every block from every eligible peer.
+- The daemon runs with `-vv`. The proxy's verbosity counter starts at `Critical`, a level it has no call sites for, so at the default it cannot report a failure at all; `-vv` reaches its `error!` and `warn!` sites without the per-request `debug!` line, which would log every RPC call with its params.
 
 ## Network Access and Interfaces
 
@@ -298,7 +299,7 @@ Build and development workflow follow the StartOS packaging guide: <https://docs
 package_id: bitcoind
 image: custom Dockerfile (copies upstream Guix-built binaries from bitcoincore.org)
 additional_images:
-  - ghcr.io/start9labs/btc-rpc-proxy:v0.5.0 (pruned node RPC proxy)
+  - ghcr.io/start9labs/btc-rpc-proxy:v0.5.1 (pruned node RPC proxy)
   - python (Alpine, RPC credential generation)
   - purplei2p/i2pd (embedded I2P)
 architectures: [x86_64, aarch64, riscv64]

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -576,10 +576,14 @@ export const main = sdk.setupMain(async ({ effects }) => {
     return {
       subcontainer,
       exec: {
-        command: ['/usr/bin/btc_rpc_proxy', '--conf', '/config.toml'] as [
-          string,
-          ...string[],
-        ],
+        // The verbosity counter starts at Critical, a level the proxy has no
+        // call sites for, so unraised it cannot report a failure at all.
+        command: [
+          '/usr/bin/btc_rpc_proxy',
+          '--conf',
+          '/config.toml',
+          '-vv',
+        ] as [string, ...string[]],
       },
       ready: {
         display: i18n('RPC Proxy'),

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -24,7 +24,7 @@ export const manifest = setupManifest({
     },
     proxy: {
       source: {
-        dockerTag: 'ghcr.io/start9labs/btc-rpc-proxy:v0.5.0',
+        dockerTag: 'ghcr.io/start9labs/btc-rpc-proxy:v0.5.1',
       },
       arch: ['x86_64', 'aarch64', 'riscv64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,96 +1,46 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '29.4:6',
+  version: '29.4:7',
   releaseNotes: {
-    en_US: `Opens up five more Bitcoin Core settings, fixes on-demand fetching of pruned blocks, and repairs the UTXO snapshot download.
+    en_US: `Updates the bundled RPC proxy that serves pruned nodes.
 
-Five more Bitcoin Core settings are now editable. Mempool Settings gains Min Transaction Relay Fee and Bytes Per Sigop; Other Settings gains Block Reconstruction Extra TXN, NAT-PMP and Max Upload Target.
+The proxy read more of Bitcoin Core's report on connected peers than it needed, insisting on fields Bitcoin Core does not always send. On Bitcoin Core 31 one of those fields went away and broke block retrieval outright, including for blocks the node still had on disk. This version was never affected — the field is still sent here — but the same trap was set: another field the proxy insisted on is reported only in some circumstances. It now reads only the three values it actually uses.
 
-The Max OP_RETURN Size field was also showing Bitcoin Core 30's default instead of this version's. It now reads 83 bytes — what Bitcoin Core 29 actually relays — and accepts up to 10,000 again.
+Two other improvements come with it. The proxy asks your own node for a block before it looks up peers, rather than the other way round, so trouble reaching the network can no longer affect a block your node still has. And it writes its errors to the service log; previously it ran at a logging level it has no messages for, so it could not report a failure at all.
 
-A pruned node keeps only recent blocks, so this package bundles a proxy that fetches any older block from the peer-to-peer network the moment something asks for it — that is what lets a Lightning node, Electrum server or block explorer work against a pruned node. The proxy was running, but the fetching itself was never switched on, so any request for a block older than your prune depth simply failed. LND, for one, could never finish building its channel graph. Those requests are now served as intended. The fetch is also cheaper: a block is pulled from a few peers rather than all of them at once. Unpruned nodes are unaffected — they never run the proxy.
+Unpruned nodes are unaffected — they never run the proxy.`,
+    es_ES: `Actualiza el proxy RPC incluido que atiende a los nodos podados.
 
-The "Download UTXO Snapshot (assumeutxo)" action has also been repaired. Every attempt failed the instant it started, reporting a missing file that had nothing to do with the address you entered — the program the action used to fetch the snapshot was no longer shipped with the service. Downloads now start as intended, and a URL that answers with an error page is reported as a failed download rather than saved as though it were a snapshot. The action is also sturdier around it: a download that stops moving is abandoned rather than leaving the action stuck on "Download in progress", a failure now tells you what went wrong instead of only that it failed, and the snapshot file — around 11 GB — is deleted once Bitcoin has absorbed it.
+El proxy leía del informe de Bitcoin Core sobre los pares conectados más de lo que necesitaba, exigiendo campos que Bitcoin Core no siempre envía. En Bitcoin Core 31 uno de esos campos desapareció y rompió por completo la obtención de bloques, incluidos los que el nodo aún tenía en disco. Esta versión nunca se vio afectada —aquí el campo se sigue enviando—, pero la trampa estaba puesta igualmente: otro campo que el proxy exigía solo se informa en determinadas circunstancias. Ahora lee únicamente los tres valores que realmente utiliza.
 
-Separately, three hardening changes from a community security audit.
+Con ello llegan otras dos mejoras. El proxy pregunta por un bloque a tu propio nodo antes de buscar pares, y no al revés, así que los problemas para llegar a la red ya no pueden afectar a un bloque que tu nodo todavía tiene. Y escribe sus errores en el registro del servicio; antes funcionaba con un nivel de registro para el que no tiene mensajes, de modo que no podía informar de ningún fallo.
 
-The check that verifies the signatures on an upstream release now counts distinct signers rather than signatures. Because it counted signatures, one release key signing several times could satisfy a quorum meant to require several independent people — so the tolerance the check advertised was not the tolerance it enforced. Nothing about the releases this package builds changes: each is signed by more than enough separate people to pass either way.
+Los nodos sin podar no se ven afectados: nunca ejecutan el proxy.`,
+    de_DE: `Aktualisiert den mitgelieferten RPC-Proxy, der beschnittene Knoten bedient.
 
-When another service asks to adjust this node's configuration, it can now reach only the handful of settings such a service has any business setting, instead of the entire configuration file. Previously such a request could also carry settings that never appeared on the screen where you approve it.
+Der Proxy las aus Bitcoin Cores Bericht über die verbundenen Gegenstellen mehr, als er brauchte, und bestand auf Feldern, die Bitcoin Core nicht immer sendet. Unter Bitcoin Core 31 fiel eines dieser Felder weg und legte das Beschaffen von Blöcken vollständig lahm — auch für Blöcke, die der Knoten noch auf der Festplatte hatte. Diese Version war nie betroffen, denn hier wird das Feld weiterhin gesendet; die Falle war aber ebenso gestellt: Ein weiteres Feld, auf dem der Proxy bestand, wird nur unter bestimmten Umständen gemeldet. Er liest jetzt nur noch die drei Werte, die er tatsächlich verwendet.
 
-And an RPC password handed over by another service must now be at least twenty characters. That field is filled in by the service requesting access and you cannot edit it, so nothing was stopping a careless one from choosing something guessable.`,
-    es_ES: `Abre cinco ajustes más de Bitcoin Core, corrige la obtención bajo demanda de bloques podados y repara la descarga de la instantánea UTXO.
+Zwei weitere Verbesserungen kommen damit. Der Proxy fragt zuerst deinen eigenen Knoten nach einem Block und sucht erst danach Gegenstellen, nicht umgekehrt — Schwierigkeiten mit dem Netz können damit keinen Block mehr betreffen, den dein Knoten noch hat. Und er schreibt seine Fehler ins Dienstprotokoll; zuvor lief er auf einer Protokollstufe, für die er keine Meldungen besitzt, und konnte deshalb überhaupt keinen Fehler melden.
 
-Cinco ajustes más de Bitcoin Core ya se pueden editar. La Configuración de Mempool incorpora Tarifa mínima de retransmisión de transacciones y Bytes por sigop; Otras configuraciones incorpora Transacciones adicionales para la reconstrucción de bloques, NAT-PMP y Objetivo máximo de subida.
+Unbeschnittene Knoten sind nicht betroffen — sie starten den Proxy nie.`,
+    pl_PL: `Aktualizuje dołączone proxy RPC, które obsługuje węzły z przycinaniem.
 
-El campo Tamaño máximo de OP_RETURN también mostraba el valor predeterminado de Bitcoin Core 30 en lugar del de esta versión. Ahora indica 83 bytes —lo que Bitcoin Core 29 retransmite realmente— y vuelve a aceptar hasta 10 000.
+Proxy czytało z raportu Bitcoin Core o połączonych węzłach więcej, niż potrzebowało, wymagając pól, których Bitcoin Core nie zawsze wysyła. W Bitcoin Core 31 jedno z tych pól zniknęło i całkowicie zepsuło pobieranie bloków — również tych, które węzeł wciąż miał na dysku. Tej wersji to nigdy nie dotyczyło, bo tutaj pole nadal jest wysyłane, ale pułapka była zastawiona tak samo: inne wymagane pole bywa podawane tylko w niektórych okolicznościach. Proxy czyta teraz wyłącznie trzy wartości, z których faktycznie korzysta.
 
-Un nodo podado solo conserva los bloques recientes, por lo que este paquete incluye un proxy que descarga cualquier bloque más antiguo de la red entre pares en cuanto algo lo solicita: eso es lo que permite que un nodo Lightning, un servidor Electrum o un explorador de bloques funcionen contra un nodo podado. El proxy estaba en marcha, pero esa descarga nunca llegó a activarse, así que cualquier petición de un bloque anterior a tu profundidad de poda fallaba sin más. LND, por ejemplo, nunca lograba terminar de construir su grafo de canales. Esas peticiones ya se atienden como corresponde. La descarga también es más económica: un bloque se solicita a unos pocos pares en lugar de a todos a la vez. Los nodos sin podar no se ven afectados: nunca ejecutan el proxy.
+Idą z tym dwie kolejne poprawki. Proxy pyta o blok najpierw twój własny węzeł, a dopiero potem szuka węzłów w sieci, a nie odwrotnie — kłopoty z siecią nie mogą już wpłynąć na blok, który twój węzeł nadal ma. I zapisuje swoje błędy w dzienniku usługi; wcześniej działało na poziomie logowania, dla którego nie ma żadnych komunikatów, więc nie mogło zgłosić żadnej awarii.
 
-También se ha reparado la acción "Descargar instantánea UTXO (assumeutxo)". Todos los intentos fallaban nada más empezar, informando de un archivo inexistente que nada tenía que ver con la dirección introducida: el programa que la acción usaba para descargar la instantánea ya no venía incluido en el servicio. Las descargas ahora arrancan como corresponde, y una URL que responde con una página de error se notifica como descarga fallida en lugar de guardarse como si fuera una instantánea. La acción también es más robusta a su alrededor: una descarga que deja de avanzar se abandona en lugar de dejar la acción atascada en "Descarga en progreso", un fallo ahora te dice qué salió mal y no solo que falló, y el archivo de la instantánea —unos 11 GB— se elimina en cuanto Bitcoin lo ha absorbido.
+Węzłów bez przycinania to nie dotyczy — nigdy nie uruchamiają proxy.`,
+    fr_FR: `Met à jour le proxy RPC embarqué qui dessert les nœuds élagués.
 
-Aparte de lo anterior, tres mejoras de robustez surgidas de una auditoría de seguridad de la comunidad.
+Le proxy lisait du rapport de Bitcoin Core sur les pairs connectés plus que nécessaire, en exigeant des champs que Bitcoin Core n'envoie pas toujours. Sous Bitcoin Core 31, l'un de ces champs a disparu et a cassé net la récupération des blocs — y compris pour ceux que le nœud avait encore sur disque. Cette version n'a jamais été concernée, car le champ y est toujours envoyé ; mais le piège était tendu de la même façon : un autre champ exigé par le proxy n'est publié que dans certaines circonstances. Il ne lit désormais que les trois valeurs dont il se sert réellement.
 
-La comprobación que verifica las firmas de una versión oficial ahora cuenta firmantes distintos en lugar de firmas. Como contaba firmas, una sola clave de publicación que firmara varias veces podía satisfacer un quórum pensado para exigir varias personas independientes, de modo que la tolerancia que anunciaba la comprobación no era la que realmente aplicaba. Nada cambia en las versiones que compila este paquete: cada una está firmada por bastantes más personas distintas de las necesarias para pasarla en cualquiera de los dos casos.
+Deux autres améliorations l'accompagnent. Le proxy interroge votre propre nœud avant de chercher des pairs, et non l'inverse : une difficulté à joindre le réseau ne peut donc plus affecter un bloc que votre nœud possède encore. Et il consigne ses erreurs dans le journal du service ; auparavant il tournait à un niveau de journalisation pour lequel il n'a aucun message, et ne pouvait donc signaler aucune panne.
 
-Cuando otro servicio solicita ajustar la configuración de este nodo, ahora solo puede llegar al puñado de ajustes que a tal servicio le corresponde tocar, en vez de a todo el archivo de configuración. Antes, esa solicitud también podía llevar ajustes que nunca aparecían en la pantalla donde usted la aprueba.
-
-Además, una contraseña RPC facilitada por otro servicio debe tener ahora al menos veinte caracteres. Ese campo lo rellena el servicio que solicita el acceso y usted no puede editarlo, así que nada impedía que uno descuidado eligiera algo fácil de adivinar.`,
-    de_DE: `Öffnet fünf weitere Einstellungen von Bitcoin Core, behebt das bedarfsgesteuerte Nachladen beschnittener Blöcke und repariert den Download des UTXO-Snapshots.
-
-Fünf weitere Einstellungen von Bitcoin Core sind jetzt editierbar. Die Mempool-Einstellungen erhalten Mindestgebühr für die Weiterleitung und Bytes pro Sigop, die Weiteren Einstellungen Zusätzliche Transaktionen für die Blockrekonstruktion, NAT-PMP und Maximales Upload-Ziel.
-
-Das Feld Maximale OP_RETURN-Größe zeigte zudem den Standardwert von Bitcoin Core 30 statt den dieser Version. Es nennt jetzt 83 Bytes — was Bitcoin Core 29 tatsächlich weiterleitet — und akzeptiert wieder bis zu 10.000.
-
-Ein beschnittener Knoten behält nur die jüngsten Blöcke, deshalb bringt dieses Paket einen Proxy mit, der jeden älteren Block in dem Moment aus dem Peer-to-Peer-Netz nachlädt, in dem etwas ihn anfordert — genau das lässt einen Lightning-Knoten, einen Electrum-Server oder einen Block-Explorer mit einem beschnittenen Knoten arbeiten. Der Proxy lief zwar, das Nachladen selbst war aber nie eingeschaltet, sodass jede Anfrage nach einem Block jenseits deiner Prune-Tiefe schlicht fehlschlug. LND etwa konnte seinen Kanalgraphen nie fertig aufbauen. Diese Anfragen werden jetzt wie vorgesehen bedient. Das Nachladen ist außerdem sparsamer: Ein Block wird von einigen wenigen Gegenstellen geholt statt von allen gleichzeitig. Unbeschnittene Knoten sind nicht betroffen — sie starten den Proxy nie.
-
-Außerdem wurde die Aktion „UTXO-Snapshot herunterladen (assumeutxo)" repariert. Jeder Versuch schlug sofort fehl und meldete eine fehlende Datei, die nichts mit der eingegebenen Adresse zu tun hatte — das Programm, mit dem die Aktion den Snapshot holte, wurde nicht mehr mit dem Dienst ausgeliefert. Downloads starten jetzt wie vorgesehen, und eine URL, die mit einer Fehlerseite antwortet, wird als fehlgeschlagener Download gemeldet, statt als Snapshot gespeichert zu werden. Auch drumherum ist die Aktion robuster: Ein Download, der nicht mehr vorankommt, wird abgebrochen, statt die Aktion bei „Download läuft" hängen zu lassen, ein Fehlschlag nennt jetzt die Ursache statt nur zu melden, dass er fehlschlug, und die Snapshot-Datei — rund 11 GB — wird gelöscht, sobald Bitcoin sie aufgenommen hat.
-
-Davon unabhängig: drei Härtungsänderungen aus einem Sicherheitsaudit der Community.
-
-Die Prüfung der Signaturen einer Upstream-Veröffentlichung zählt jetzt unterschiedliche Signierende statt Signaturen. Da sie Signaturen zählte, konnte ein einzelner Veröffentlichungsschlüssel durch mehrfaches Signieren ein Quorum erfüllen, das mehrere unabhängige Personen verlangen sollte — die Toleranz, die die Prüfung angab, war also nicht die, die sie durchsetzte. An den Veröffentlichungen, die dieses Paket baut, ändert sich nichts: Jede ist von mehr als genug verschiedenen Personen signiert, um so oder so zu bestehen.
-
-Wenn ein anderer Dienst darum bittet, die Konfiguration dieses Knotens anzupassen, erreicht er jetzt nur noch die wenigen Einstellungen, die einen solchen Dienst überhaupt etwas angehen, statt der gesamten Konfigurationsdatei. Zuvor konnte eine solche Anfrage auch Einstellungen enthalten, die auf dem Bildschirm, auf dem Sie sie bestätigen, nie auftauchten.
-
-Und ein von einem anderen Dienst übergebenes RPC-Passwort muss nun mindestens zwanzig Zeichen lang sein. Dieses Feld füllt der anfragende Dienst aus und Sie können es nicht ändern — nichts hielt also einen nachlässigen Dienst davon ab, etwas leicht Erratbares zu wählen.`,
-    pl_PL: `Udostępnia pięć kolejnych ustawień Bitcoin Core, naprawia pobieranie na żądanie bloków usuniętych przez przycinanie oraz pobieranie migawki UTXO.
-
-Pięć kolejnych ustawień Bitcoin Core można teraz edytować. Ustawienia Mempool zyskują Minimalną opłatę za przekazywanie transakcji i Bajty na sigop, a Inne ustawienia — Dodatkowe transakcje do rekonstrukcji bloków, NAT-PMP i Maksymalny limit wysyłania.
-
-Pole Maksymalny rozmiar OP_RETURN pokazywało ponadto wartość domyślną z Bitcoin Core 30 zamiast z tej wersji. Teraz podaje 83 bajty — tyle, ile Bitcoin Core 29 rzeczywiście przekazuje — i ponownie przyjmuje do 10 000.
-
-Węzeł z włączonym przycinaniem przechowuje tylko najnowsze bloki, dlatego pakiet zawiera proxy, które pobiera każdy starszy blok z sieci peer-to-peer w chwili, gdy coś go zażąda — to właśnie pozwala węzłowi Lightning, serwerowi Electrum czy eksploratorowi bloków działać na przyciętym węźle. Proxy działało, ale samo pobieranie nigdy nie zostało włączone, więc każde żądanie bloku starszego niż twoja głębokość przycinania po prostu kończyło się błędem. LND na przykład nigdy nie potrafił dokończyć budowy swojego grafu kanałów. Te żądania są już obsługiwane zgodnie z założeniem. Samo pobieranie jest też tańsze: blok jest ściągany od kilku węzłów zamiast od wszystkich naraz. Węzłów bez przycinania to nie dotyczy — nigdy nie uruchamiają proxy.
-
-Naprawiono również akcję „Pobierz migawkę UTXO (assumeutxo)". Każda próba kończyła się błędem natychmiast po uruchomieniu, zgłaszając brakujący plik niemający nic wspólnego z podanym adresem — program, którym akcja pobierała migawkę, przestał być dostarczany razem z usługą. Pobieranie zaczyna się teraz zgodnie z założeniem, a adres URL zwracający stronę błędu jest zgłaszany jako nieudane pobranie, zamiast zostać zapisany tak, jakby był migawką. Sama akcja jest też odporniejsza: pobieranie, które przestaje postępować, zostaje przerwane, zamiast zostawiać akcję zablokowaną na „Pobieranie w toku", niepowodzenie podaje teraz przyczynę, a nie tylko sam fakt błędu, a plik migawki — około 11 GB — jest usuwany, gdy tylko Bitcoin go wchłonie.
-
-Niezależnie od powyższego: trzy zmiany wzmacniające, wynikające ze społecznościowego audytu bezpieczeństwa.
-
-Kontrola weryfikująca podpisy wydania upstream liczy teraz odrębnych sygnatariuszy, a nie podpisy. Ponieważ liczyła podpisy, jeden klucz wydania podpisujący kilkakrotnie mógł spełnić kworum pomyślane tak, by wymagać kilku niezależnych osób — deklarowana odporność kontroli nie była więc tą, którą faktycznie egzekwowała. W wydaniach budowanych przez ten pakiet nic się nie zmienia: każde jest podpisane przez znacznie więcej odrębnych osób, niż potrzeba do jej przejścia w obu wariantach.
-
-Gdy inna usługa prosi o zmianę konfiguracji tego węzła, może teraz sięgnąć wyłącznie po tę garstkę ustawień, które takiej usługi w ogóle dotyczą, zamiast po cały plik konfiguracyjny. Wcześniej takie żądanie mogło nieść również ustawienia, które nigdy nie pojawiały się na ekranie zatwierdzania.
-
-Hasło RPC przekazane przez inną usługę musi mieć teraz co najmniej dwadzieścia znaków. To pole wypełnia usługa prosząca o dostęp i nie można go edytować, więc nic nie powstrzymywało nieostrożnej usługi przed wybraniem czegoś łatwego do odgadnięcia.`,
-    fr_FR: `Ouvre cinq réglages supplémentaires de Bitcoin Core, corrige la récupération à la demande des blocs élagués et répare le téléchargement de l'instantané UTXO.
-
-Cinq réglages supplémentaires de Bitcoin Core sont désormais modifiables. Les Paramètres du Mempool gagnent Frais minimum de relais des transactions et Octets par sigop ; les Autres paramètres gagnent Transactions supplémentaires pour la reconstruction des blocs, NAT-PMP et Objectif maximal d'envoi.
-
-Le champ Taille maximale OP_RETURN affichait par ailleurs la valeur par défaut de Bitcoin Core 30 plutôt que celle de cette version. Il indique désormais 83 octets — ce que Bitcoin Core 29 relaie réellement — et accepte de nouveau jusqu'à 10 000.
-
-Un nœud élagué ne conserve que les blocs récents ; ce paquet embarque donc un proxy qui récupère n'importe quel bloc plus ancien sur le réseau pair-à-pair dès que quelque chose le demande — c'est ce qui permet à un nœud Lightning, un serveur Electrum ou un explorateur de blocs de fonctionner avec un nœud élagué. Le proxy tournait, mais cette récupération n'a jamais été activée : toute demande d'un bloc antérieur à votre profondeur d'élagage échouait purement et simplement. LND, par exemple, ne parvenait jamais à terminer la construction de son graphe de canaux. Ces demandes sont désormais servies comme prévu. La récupération est aussi moins coûteuse : un bloc est demandé à quelques pairs plutôt qu'à tous à la fois. Les nœuds non élagués ne sont pas concernés : ils n'exécutent jamais le proxy.
-
-L'action « Télécharger l'instantané UTXO (assumeutxo) » a également été réparée. Chaque tentative échouait dès son lancement en signalant un fichier introuvable sans rapport avec l'adresse saisie : le programme que l'action utilisait pour récupérer l'instantané n'était plus livré avec le service. Les téléchargements démarrent désormais comme prévu, et une URL qui répond par une page d'erreur est signalée comme un téléchargement échoué au lieu d'être enregistrée comme s'il s'agissait d'un instantané. L'action est aussi plus robuste autour : un téléchargement qui n'avance plus est abandonné au lieu de laisser l'action bloquée sur « Téléchargement en cours », un échec indique désormais ce qui a mal tourné et non plus seulement qu'il a échoué, et le fichier d'instantané — environ 11 Go — est supprimé une fois que Bitcoin l'a absorbé.
-
-Par ailleurs, trois renforcements issus d'un audit de sécurité communautaire.
-
-La vérification des signatures d'une version amont compte désormais des signataires distincts plutôt que des signatures. Comme elle comptait les signatures, une seule clé de publication signant plusieurs fois pouvait satisfaire un quorum censé exiger plusieurs personnes indépendantes : la tolérance annoncée par la vérification n'était donc pas celle qu'elle appliquait. Rien ne change pour les versions que ce paquet construit : chacune est signée par bien plus de personnes distinctes qu'il n'en faut pour passer dans les deux cas.
-
-Lorsqu'un autre service demande à modifier la configuration de ce nœud, il n'atteint plus que la poignée de réglages qui le concernent réellement, au lieu de l'ensemble du fichier de configuration. Auparavant, une telle demande pouvait aussi porter des réglages qui n'apparaissaient jamais sur l'écran où vous la validez.
-
-Enfin, un mot de passe RPC fourni par un autre service doit désormais compter au moins vingt caractères. Ce champ est rempli par le service qui demande l'accès et vous ne pouvez pas le modifier : rien n'empêchait donc un service négligent de choisir quelque chose de facile à deviner.`,
+Les nœuds non élagués ne sont pas concernés : ils n'exécutent jamais le proxy.`,
   },
   migrations: {
     up: async ({ effects }) => {},
     down: async ({ effects }) => {},
   },
-}).satisfies('28.4:19')
+}).satisfies('28.4:20')


### PR DESCRIPTION
Companion to #271, which is the urgent one — **this line was never affected by #270** and the release notes say so rather than claiming a fix users never needed.

Core 31.0 hid `startingheight` behind `-deprecatedrpc=startingheight`. The proxy's `PeerInfo` named it mandatory, so on 31.x `getpeerinfo` stopped deserializing — and because the interceptor resolved the peer list before asking bitcoind whether it even had the block, every `getblock` at verbosity 0 or 1 failed, on-disk blocks included.

This line still emits `startingheight`, so nothing here broke. But `PeerInfo` also required `addrbind`, which Core emits only when the bind address is valid. Same trap, unsprung — which is why the re-pin belongs on every branch rather than 31.x alone.

**What's here**

- Proxy re-pinned to `v0.5.1` (Start9Labs/btc-rpc-proxy#28): `PeerInfo` declares only the three fields the peer list selects on, and the peer list is resolved only after bitcoind reports a block pruned, so a fetch-side failure can no longer affect a block the node still has. Errors also carry their source chain now.
- The daemon gains `-vv`. The proxy's verbosity counter starts at `Critical` and the binary has no `crit!` call sites anywhere, so it was structurally incapable of logging anything — the failure on 31.x was logged at `Error` the whole time and filtered out. `-vv` stops short of the per-request `debug!` line, which would log every RPC call with its params.
- `satisfies` tracks the sibling branches, all bumped in this wave.

In-place version bump: this file's `up` is empty, so nothing is dropped from the graph.

**CI will fail until the `v0.5.1` image finishes publishing** — the tag is pushed and the multi-arch build is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)