### PR TITLE
fix: I2P health-check and config cleanups; 29.4:8 → 29.4:9

### DIFF
--- a/startos/fileModels/bitcoin.conf.ts
+++ b/startos/fileModels/bitcoin.conf.ts
@@ -145,6 +145,10 @@ export const shape = z.object({
     .catch(undefined),
   peerblockfilters: iniBoolean,
   natpmp: iniBoolean,
+  // Must-be-absent, like the credential pair above: a Bitcoin Knots (RDTS)
+  // switch can leave this behind, and this build logs "Ignoring unknown
+  // configuration value" for it on every start.
+  consensusrules: z.undefined().optional().catch(undefined),
   maxuploadtarget: iniNumber,
 })
 

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -376,6 +376,11 @@ export const main = sdk.setupMain(async ({ effects }) => {
       await i2pdSub.execFail(['rm', '-rf', '/home/i2pd/data/certificates'], {
         user: 'root',
       })
+      // i2pd warns on every start if the client-tunnels file is absent; we
+      // ship no client tunnels, so seed an empty one (chown below owns it)
+      await i2pdSub.execFail(['touch', '/home/i2pd/data/tunnels.conf'], {
+        user: 'root',
+      })
       // Fix volume ownership for the non-root i2pd user
       await i2pdSub.execFail(['chown', '-R', 'i2pd', '/home/i2pd'], {
         user: 'root',
@@ -406,6 +411,17 @@ export const main = sdk.setupMain(async ({ effects }) => {
               const netStatus = info?.result?.['i2p.router.net.status']
               const knownPeers = info?.result?.['i2p.router.netdb.knownpeers']
               const activePeers = info?.result?.['i2p.router.netdb.activepeers']
+
+              // A reply without a usable `result` (e.g. a JSON-RPC error
+              // object) used to slip through every guard below — undefined
+              // compares false against numbers — and report success. Fail
+              // toward `starting` instead.
+              if (info?.result == null || netStatus == null) {
+                return {
+                  result: 'starting' as const,
+                  message: i18n('Starting the I2P router'),
+                }
+              }
 
               // An empty netDb means reseed never landed — the router has
               // nothing to connect to and will not recover on its own. It

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,23 +1,33 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '29.4:8',
+  version: '29.4:9',
   releaseNotes: {
-    en_US: `Stops the embedded I2P router logging an error every thirty seconds.
+    en_US: `Small cleanups around the embedded I2P router.
 
-The health check that reports I2P status logged in before each query and handed the token it received back with that query. i2pd reads the token as a request it does not recognise and records an error for it — twice a minute, for as long as I2P is switched on. Nothing was actually wrong: I2P connectivity was unaffected and the check itself always reported correctly. The check now asks the router directly without logging in, which i2pd accepts because it never verifies the token it issues.`,
-    es_ES: `Evita que el router I2P integrado registre un error cada treinta segundos.
+- If you switched to Bitcoin Core from Bitcoin Knots (RDTS), a leftover consensusrules line in bitcoin.conf made every start log "Ignoring unknown configuration value". It is now removed automatically.
+- The I2P health check treated an unusable reply from the router as healthy; it now reports "starting" until the router gives a real answer.
+- i2pd no longer warns on every start about an optional tunnels file that was never shipped.`,
+    es_ES: `Pequeñas limpiezas en torno al router I2P integrado.
 
-La comprobación de estado que informa del estado de I2P iniciaba sesión antes de cada consulta y devolvía junto a ella el token recibido. i2pd interpreta ese token como una petición que no reconoce y registra un error por él: dos veces por minuto, mientras I2P esté activado. En realidad no pasaba nada: la conectividad I2P no se veía afectada y la propia comprobación siempre informaba correctamente. Ahora la comprobación consulta al router directamente, sin iniciar sesión, algo que i2pd acepta porque nunca verifica el token que emite.`,
-    de_DE: `Verhindert, dass der eingebettete I2P-Router alle dreißig Sekunden einen Fehler protokolliert.
+- Si cambiaste a Bitcoin Core desde Bitcoin Knots (RDTS), una línea consensusrules sobrante en bitcoin.conf hacía que cada arranque registrara «Ignoring unknown configuration value». Ahora se elimina automáticamente.
+- La comprobación de estado de I2P trataba una respuesta inutilizable del router como si todo fuera bien; ahora informa «iniciando» hasta que el router da una respuesta real.
+- i2pd ya no avisa en cada arranque sobre un archivo de túneles opcional que nunca se incluyó.`,
+    de_DE: `Kleine Aufräumarbeiten rund um den eingebetteten I2P-Router.
 
-Die Zustandsprüfung, die den I2P-Status meldet, meldete sich vor jeder Abfrage an und reichte das erhaltene Token mit der Abfrage zurück. i2pd liest dieses Token als Anfrage, die es nicht kennt, und protokolliert dafür einen Fehler — zweimal pro Minute, solange I2P eingeschaltet ist. Tatsächlich war nichts kaputt: Die I2P-Verbindung war nicht betroffen, und die Prüfung selbst meldete stets korrekt. Die Prüfung fragt den Router jetzt direkt ab, ohne sich anzumelden; i2pd akzeptiert das, weil es das ausgegebene Token ohnehin nie überprüft.`,
-    pl_PL: `Sprawia, że wbudowany router I2P przestaje zapisywać błąd co trzydzieści sekund.
+- Wer von Bitcoin Knots (RDTS) zu Bitcoin Core gewechselt ist, hatte eine übrig gebliebene consensusrules-Zeile in der bitcoin.conf, die bei jedem Start "Ignoring unknown configuration value" protokollierte. Sie wird jetzt automatisch entfernt.
+- Die I2P-Zustandsprüfung wertete eine unbrauchbare Antwort des Routers als gesund; sie meldet jetzt "startet", bis der Router eine echte Antwort gibt.
+- i2pd warnt beim Start nicht mehr über eine optionale Tunnel-Datei, die nie mitgeliefert wurde.`,
+    pl_PL: `Drobne porządki wokół wbudowanego routera I2P.
 
-Kontrola stanu raportująca status I2P logowała się przed każdym zapytaniem i odsyłała otrzymany token razem z tym zapytaniem. i2pd odczytuje ten token jako żądanie, którego nie rozpoznaje, i zapisuje z jego powodu błąd — dwa razy na minutę, dopóki I2P jest włączone. W rzeczywistości nic nie było nie tak: łączność I2P pozostawała nienaruszona, a sama kontrola zawsze raportowała poprawnie. Kontrola odpytuje teraz router bezpośrednio, bez logowania, co i2pd akceptuje, ponieważ i tak nigdy nie weryfikuje wydawanego tokenu.`,
-    fr_FR: `Empêche le routeur I2P intégré de consigner une erreur toutes les trente secondes.
+- Jeśli przeszedłeś na Bitcoin Core z Bitcoin Knots (RDTS), pozostawiona linia consensusrules w bitcoin.conf sprawiała, że każdy start zapisywał "Ignoring unknown configuration value". Teraz jest usuwana automatycznie.
+- Kontrola stanu I2P traktowała bezużyteczną odpowiedź routera jako zdrową; teraz zgłasza "uruchamianie", dopóki router nie udzieli prawdziwej odpowiedzi.
+- i2pd nie ostrzega już przy każdym starcie o opcjonalnym pliku tuneli, którego nigdy nie dołączano.`,
+    fr_FR: `Petits nettoyages autour du routeur I2P intégré.
 
-La vérification d'état qui rapporte le statut d'I2P s'authentifiait avant chaque requête et renvoyait avec celle-ci le jeton obtenu. i2pd lit ce jeton comme une requête qu'il ne reconnaît pas et consigne une erreur à son sujet — deux fois par minute, tant qu'I2P est activé. En réalité rien n'était en panne : la connectivité I2P n'était pas affectée et la vérification elle-même rapportait toujours correctement. La vérification interroge désormais le routeur directement, sans s'authentifier, ce que i2pd accepte puisqu'il ne vérifie jamais le jeton qu'il délivre.`,
+- Si vous êtes passé à Bitcoin Core depuis Bitcoin Knots (RDTS), une ligne consensusrules restée dans bitcoin.conf faisait consigner « Ignoring unknown configuration value » à chaque démarrage. Elle est désormais retirée automatiquement.
+- La vérification d'état d'I2P considérait une réponse inutilisable du routeur comme saine ; elle signale désormais « démarrage » tant que le routeur ne donne pas de vraie réponse.
+- i2pd n'avertit plus à chaque démarrage au sujet d'un fichier de tunnels optionnel qui n'a jamais été fourni.`,
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
Three small cleanups from a support case whose log was dominated by i2pd output (same case as #261's second half).

- **Model `consensusrules` as must-be-absent**, alongside `rpcuser`, `rpcpassword` and `mempoolfullrbf`. A Bitcoin Knots (RDTS) switch that predates its `clearFlavorKeys` migrations leaves the key behind, and Core logs `Ignoring unknown configuration value` for it on every start. `onRead` runs `shape.parse`, so the key is coerced away on read and never re-emitted by `onWrite` — every write strips it, and no init-time heal is needed.
- **Fail the I2P health check closed:** a RouterInfo error reply parsed fine, slipped past every guard (`undefined` compares false against numbers), and reported **success** on a router that answered nothing. It now reports `starting` until there's a real answer.
- **Seed an empty `tunnels.conf`** so i2pd stops warning about the optional client-tunnels file on every start.

**Verification:** `tsc` clean, prettier clean. Not exercised against a live box — the `consensusrules` handling is the same shape-level mechanism that already strips the credential pair on every write.

**Context:** Follow-up to the I2PControl cleanup pushed to all flavor branches on Aug 13 (*"stop the I2P health check provoking an i2pd error"*, related to #261). That change dropped the unvalidated `Authenticate`/`Token` round-trip; this one adds the missing fail-closed guard under the same call — if i2pd ever starts validating tokens (PurpleI2P/i2pd#2138), tokenless `RouterInfo` returns error replies, and without this guard the check would report success on a router it can no longer see. The `consensusrules` handling completes Knots 29.4's `clearFlavorKeys` (which cleans future switches on the way out) by healing boxes that crossed **before** it shipped.

Same change on the sibling Core branches (#275 31.x, #276 28.x, #277 29.x, #278 30.x), and Start9Labs/bitcoin-knots-startos#46 / #47 for the two Knots flavors — I2P halves only, since Knots RDTS wants `consensusrules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
