### PR TITLE
feat: index-sync health check, sync-progress detail, and a bounded chain-recovery CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,21 +234,24 @@ One task, and it exists only to report a failure that happens after the action t
 
 ## Health Checks
 
-Six checks at most, and three of them can never report a failure: they describe the node's reachability posture rather than its health.
+Seven checks at most, and three of them can never report a failure: they describe the node's reachability posture rather than its health.
 
-| Check           | Displayed       | Probes                                                                       | Grace       | Present                                    |
-| --------------- | --------------- | ---------------------------------------------------------------------------- | ----------- | ------------------------------------------ |
-| `bitcoind`      | RPC             | Waits for `.cookie` to appear, then that the RPC port is listening           | SDK default | always                                     |
-| `sync-progress` | Blockchain Sync | `getblockchaininfo` plus `getchaintips`, every 30 s (5 s while starting or failing)              | —           | always                                     |
-| `i2pd`          | I2P             | i2pd's I2PControl `RouterInfo` on loopback                                   | 5 minutes   | while I2P is enabled                       |
-| `i2p`           | I2P             | nothing — a `disabled` placeholder in place of the daemon check              | —           | while I2P is off, or excluded by `onlynet` |
-| `tor`           | Tor             | Tor's installed and running state, and whether an onion address is published | —           | always                                     |
-| `clearnet`      | Clearnet        | Whether a non-onion address is published                                     | —           | always                                     |
-| `proxy`         | RPC Proxy       | That the proxy's port is listening                                           | —           | while the node is pruned                   |
+| Check           | Displayed       | Probes                                                                                       | Grace       | Present                                    |
+| --------------- | --------------- | -------------------------------------------------------------------------------------------- | ----------- | ------------------------------------------ |
+| `bitcoind`      | RPC             | Waits for `.cookie` to appear, then that the RPC port is listening                           | SDK default | always                                     |
+| `sync-progress` | Blockchain Sync | `getblockchaininfo` plus `getchaintips`, every 30 s (5 s while starting or failing)          | —           | always                                     |
+| `index-sync`    | Index Sync      | `getindexinfo`, plus `getblockchaininfo` only while an index is behind, on the same schedule | —           | always                                     |
+| `i2pd`          | I2P             | i2pd's I2PControl `RouterInfo` on loopback                                                   | 5 minutes   | while I2P is enabled                       |
+| `i2p`           | I2P             | nothing — a `disabled` placeholder in place of the daemon check                              | —           | while I2P is off, or excluded by `onlynet` |
+| `tor`           | Tor             | Tor's installed and running state, and whether an onion address is published                 | —           | always                                     |
+| `clearnet`      | Clearnet        | Whether a non-onion address is published                                                     | —           | always                                     |
+| `proxy`         | RPC Proxy       | That the proxy's port is listening                                                           | —           | while the node is pruned                   |
 
 **`bitcoind` failing** means the RPC port never opened. The cookie is deleted at the start of every run and recreated by bitcoind itself, so a check still waiting on it is one where bitcoind is not reaching the point of serving RPC — read the service logs for a startup or database error rather than looking for a networking fault.
 
-**`sync-progress` is a progress meter, not a fault indicator.** It reports a percentage for the whole of the Initial Block Download, which legitimately runs for hours to days. It succeeds once bitcoind clears `initialblockdownload`, and also while that flag is still set if `getchaintips` reports no non-invalid tip above the active one — the flag lags a node that has in fact caught up, and a node with nothing above its tip has nothing left to fetch. It reports `starting` whenever the RPC call fails, which is normal while the node is coming up.
+**`sync-progress` is a progress meter, not a fault indicator.** It reports a percentage for the whole of the Initial Block Download, which legitimately runs for hours to days. It succeeds once bitcoind clears `initialblockdownload`, and also while that flag is still set if `getchaintips` reports no non-invalid tip above the active one — the flag lags a node that has in fact caught up, and a node with nothing above its tip has nothing left to fetch. It reports `starting` whenever the RPC call fails, which is normal while the node is coming up; when the failure is RPC warmup (`-28`) the message carries bitcoind's own account of what it is doing, so a long `Verifying blocks…` or the `Replaying blocks…` that follows an unclean stop is visible rather than indistinguishable from a hang. Before the first block connects it reports the height of the header chain rather than a block percentage that would sit at 0.00% for the whole of that phase. The two chain checks share one probe for their RPC calls, so both separate a node that is not answering yet — `starting` — from a call that could not be run at all or a reply that could not be parsed, which is the only condition under which either reports `failure`.
+
+**`index-sync` is separate from `sync-progress` because the indexes are.** `getindexinfo` lists only the indexes actually enabled, so the check reports `disabled` when there are none and success when every one of them sits at the tip — the normal state throughout IBD, where an index follows block connection rather than trailing it. It goes to `loading` when one falls behind, naming the furthest behind and its height as a percentage of the chain tip. The case it exists for is enabling an index on a node that is already synced: that starts a backfill from the first block, during which `getrawtransaction`, `getblockfilter`, and `gettxoutsetinfo` answer for only the part of the chain the index has reached, while `sync-progress` reports the node fully synced. An index that is behind is working, not broken, so that reads as `loading`; the only thing that reddens this check is bitcoind failing to answer or answering with something unreadable.
 
 **`i2pd` is the one check written to distinguish "slow" from "never".** Everything reads as starting during the five-minute grace period. Past it, an empty network database means the router never reached a reseed server and will not recover on its own; a reported router error status is surfaced with its number; and a router that has reseeded but built no tunnels yet reports `starting`, because that one does resolve itself.
 
@@ -333,6 +336,7 @@ tasks:
 health_checks:
   - bitcoind # the daemon's ready check, displayed "RPC"
   - sync-progress # displayed "Blockchain Sync"
+  - index-sync # displayed "Index Sync"
   - i2pd # displayed "I2P"; only while I2P is enabled
   - i2p # displayed "I2P"; the disabled placeholder otherwise
   - tor

--- a/instructions.md
+++ b/instructions.md
@@ -47,6 +47,8 @@ Four actions write to `bitcoin.conf` for you. Only values that differ from upstr
 - **RPC Settings** — RPC server timeout, thread count, and work-queue depth.
 - **Other Settings** — ZeroMQ, `txindex`, coinstats index, BIP158/BIP157 block filters, bloom filters, wallet options, pruning, database cache tuning, compact-block reconstruction memory, NAT-PMP port mapping, and a daily upload limit.
 
+Turning on `txindex`, the coinstats index, or block filters after the chain is already synced starts a rebuild from the first block. The **Index Sync** health check on the Dashboard tracks it, and anything relying on that index — transaction lookups, filter-based wallet scans — stays incomplete until it finishes, even though the node itself reports fully synced.
+
 Some options are fixed by the package and not exposed: RPC cookie authentication, the peer listen ports, `assumevalid`, and the Tor proxy. Advanced i2pd-daemon tuning isn't in the UI either — edit `i2pd.conf` on the `i2pd` volume if you need it.
 
 ### Maintenance

--- a/startos/forkRecovery.ts
+++ b/startos/forkRecovery.ts
@@ -50,12 +50,20 @@ import { GetBlockchainInfo, bitcoinCliArgs } from './utils'
 
 /** A container that can run bitcoin-cli against the live bitcoind. */
 export type CliRunner = {
-  exec: (cmd: string[]) => Promise<{
+  exec(
+    cmd: string[],
+    options?: undefined,
+    timeoutMs?: number | null,
+    abort?: AbortController,
+  ): Promise<{
     exitCode: number | null
+    exitSignal: NodeJS.Signals | null
     stdout: string | Buffer
     stderr: string | Buffer
   }>
 }
+
+export type CliOpts = { prune: boolean; abort?: AbortController }
 
 export type GetDeploymentInfo = {
   hash: string
@@ -78,19 +86,29 @@ export type ChainTip = {
 
 const cli = async (
   subc: CliRunner,
-  opts: { prune: boolean },
+  opts: CliOpts,
   ...cmd: string[]
 ): Promise<string> => {
-  const res = await subc.exec([
-    ...bitcoinCliArgs({ prune: opts.prune }),
-    '-rpcconnect=127.0.0.1',
-    '-rpcwait',
-    '-rpcclienttimeout=0',
-    ...cmd,
-  ])
+  // exec SIGKILLs at 30 s by default, contradicting the flags below: every
+  // call blocks through RPC warmup, and reconsiderblock reorgs synchronously.
+  // opts.abort, raised when the service stops, is the bound instead.
+  const res = await subc.exec(
+    [
+      ...bitcoinCliArgs({ prune: opts.prune }),
+      '-rpcconnect=127.0.0.1',
+      '-rpcwait',
+      '-rpcclienttimeout=0',
+      ...cmd,
+    ],
+    undefined,
+    null,
+    opts.abort,
+  )
   if (res.exitCode !== 0) {
     throw new Error(
-      `bitcoin-cli ${cmd[0]} failed (${res.exitCode}): ${String(res.stderr)}`,
+      res.exitSignal
+        ? `bitcoin-cli ${cmd[0]} killed by ${res.exitSignal}`
+        : `bitcoin-cli ${cmd[0]} failed (${res.exitCode}): ${String(res.stderr)}`,
     )
   }
   return String(res.stdout)
@@ -98,7 +116,7 @@ const cli = async (
 
 const cliJson = async <T>(
   subc: CliRunner,
-  opts: { prune: boolean },
+  opts: CliOpts,
   ...cmd: string[]
 ): Promise<T> => JSON.parse(await cli(subc, opts, ...cmd)) as T
 
@@ -118,7 +136,7 @@ const cliJson = async <T>(
  */
 export async function isRdtsEnforcing(
   subc: CliRunner,
-  opts: { prune: boolean },
+  opts: CliOpts,
 ): Promise<boolean> {
   const info = await cliJson<GetDeploymentInfo>(subc, opts, 'getdeploymentinfo')
   return info.deployments['reduced_data'] !== undefined
@@ -156,7 +174,7 @@ export type ReconsiderResult = {
  */
 export async function reconsiderInvalidTips(
   subc: CliRunner,
-  opts: { prune: boolean },
+  opts: CliOpts,
 ): Promise<ReconsiderResult> {
   const result: ReconsiderResult = { reconsidered: [], skippedPruned: [] }
   // Re-fetch tips and chain info every iteration: each reconsiderblock can

--- a/startos/i18n/dictionaries/default.ts
+++ b/startos/i18n/dictionaries/default.ts
@@ -13,6 +13,15 @@ const dict = {
   'The Bitcoin RPC Proxy is not ready': 9,
   'Sync Complete': 10,
   'The blockchain is fully synced.': 11,
+  'Bitcoin is starting: ${step}': 12,
+  'Syncing block headers…': 13,
+  'Syncing block headers: ${count}': 14,
+  'Index Sync': 15,
+  'No indexes are enabled': 16,
+  'All enabled indexes are up to date': 17,
+  'Building ${index}: ${percentage}%': 18,
+  'Block Filter Index': 19,
+  'Could not read ${cmd} from Bitcoin: ${error}': 20,
 
   // interfaces.ts
   RPC: 100,

--- a/startos/i18n/dictionaries/translations.ts
+++ b/startos/i18n/dictionaries/translations.ts
@@ -14,6 +14,15 @@ export default {
     9: 'El proxy RPC de Bitcoin no está listo',
     10: 'Sincronización completa',
     11: 'La blockchain está completamente sincronizada.',
+    12: 'Bitcoin está iniciando: ${step}',
+    13: 'Sincronizando cabeceras de bloques…',
+    14: 'Sincronizando cabeceras de bloques: ${count}',
+    15: 'Sincronización de índices',
+    16: 'No hay índices habilitados',
+    17: 'Todos los índices habilitados están actualizados',
+    18: 'Construyendo ${index}: ${percentage}%',
+    19: 'Índice de filtros de bloques',
+    20: 'No se pudo leer ${cmd} de Bitcoin: ${error}',
 
     // interfaces.ts
     100: 'RPC',
@@ -310,6 +319,15 @@ export default {
     9: 'Der Bitcoin RPC-Proxy ist nicht bereit',
     10: 'Synchronisierung abgeschlossen',
     11: 'Die Blockchain ist vollständig synchronisiert.',
+    12: 'Bitcoin startet: ${step}',
+    13: 'Blockheader werden synchronisiert…',
+    14: 'Blockheader werden synchronisiert: ${count}',
+    15: 'Index-Synchronisierung',
+    16: 'Keine Indizes aktiviert',
+    17: 'Alle aktivierten Indizes sind aktuell',
+    18: '${index} wird aufgebaut: ${percentage}%',
+    19: 'Blockfilter-Index',
+    20: '${cmd} konnte nicht von Bitcoin gelesen werden: ${error}',
 
     // interfaces.ts
     100: 'RPC',
@@ -606,6 +624,15 @@ export default {
     9: 'Proxy RPC Bitcoin nie jest gotowy',
     10: 'Synchronizacja zakończona',
     11: 'Łańcuch bloków jest w pełni zsynchronizowany.',
+    12: 'Bitcoin uruchamia się: ${step}',
+    13: 'Synchronizowanie nagłówków bloków…',
+    14: 'Synchronizowanie nagłówków bloków: ${count}',
+    15: 'Synchronizacja indeksów',
+    16: 'Żadne indeksy nie są włączone',
+    17: 'Wszystkie włączone indeksy są aktualne',
+    18: 'Budowanie ${index}: ${percentage}%',
+    19: 'Indeks filtrów bloków',
+    20: 'Nie udało się odczytać ${cmd} z Bitcoina: ${error}',
 
     // interfaces.ts
     100: 'RPC',
@@ -902,6 +929,15 @@ export default {
     9: "Le proxy RPC Bitcoin n'est pas prêt",
     10: 'Synchronisation terminée',
     11: 'La blockchain est entièrement synchronisée.',
+    12: 'Bitcoin démarre : ${step}',
+    13: 'Synchronisation des en-têtes de blocs…',
+    14: 'Synchronisation des en-têtes de blocs : ${count}',
+    15: 'Synchronisation des index',
+    16: 'Aucun index activé',
+    17: 'Tous les index activés sont à jour',
+    18: 'Construction de ${index} : ${percentage}%',
+    19: 'Index des filtres de blocs',
+    20: 'Impossible de lire ${cmd} depuis Bitcoin : ${error}',
 
     // interfaces.ts
     100: 'RPC',

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -1,4 +1,4 @@
-import { TOML } from '@start9labs/start-sdk'
+import { healthFns, TOML } from '@start9labs/start-sdk'
 import { access, rm, writeFile } from 'fs/promises'
 import { request } from 'node:https'
 import { socksHostId, socksPort } from 'tor-startos/startos/utils'
@@ -50,6 +50,38 @@ const i2pControlRpc = (method: string, params: Record<string, unknown>) =>
     req.write(body)
     req.end()
   })
+
+/**
+ * "Still starting", carrying bitcoind's own reason when it gave one.
+ * bitcoin-cli exits |code| and writes `error code: <n>`, `error message:`, then
+ * the message; -28 is RPC_IN_WARMUP, whose message is the startup step the node
+ * is on ("Verifying blocks…", or "Replaying blocks…" after an unclean stop).
+ */
+const startingResult = (res: {
+  exitCode: number | null
+  stderr: string | Buffer
+}) => {
+  const step =
+    res.exitCode === 28
+      ? String(res.stderr).split('\n').slice(2).join('\n').trim()
+      : ''
+  return {
+    result: 'starting' as const,
+    message: step
+      ? i18n('Bitcoin is starting: ${step}', { step })
+      : i18n('Bitcoin is starting…'),
+  }
+}
+
+/** getindexinfo's keys, as the settings screens label them. */
+const indexLabel = (name: string) =>
+  name === 'txindex'
+    ? i18n('Transaction Index')
+    : name === 'basic block filter index'
+      ? i18n('Block Filter Index')
+      : name === 'coinstatsindex'
+        ? i18n('Coinstats Index')
+        : name
 
 export const main = sdk.setupMain(async ({ effects }) => {
   /**
@@ -120,6 +152,44 @@ export const main = sdk.setupMain(async ({ effects }) => {
     force: true,
     recursive: true,
   })
+
+  /**
+   * One read-only bitcoin-cli call for the health checks below, parsed. Every
+   * outcome is a value: a node not answering yet reads as `starting` (carrying
+   * its warmup step where it gave one), and a call that cannot be run or whose
+   * reply cannot be parsed reads as `failure`, neither being a state bitcoind
+   * reaches while it is running normally. `exec` rather than `execFail`
+   * because a non-zero exit is the expected signal here, not an error.
+   */
+  const probe = async <T>(
+    ...cmd: string[]
+  ): Promise<{ value: T } | { health: healthFns.HealthCheckResult }> => {
+    try {
+      const res = await bitcoindSub.exec([
+        ...bitcoinCliArgs({ prune: !!bitcoinConf.prune }),
+        '-rpcconnect=127.0.0.1',
+        ...cmd,
+      ])
+      if (
+        res.exitCode !== 0 ||
+        typeof res.stdout !== 'string' ||
+        res.stdout === ''
+      ) {
+        return { health: startingResult(res) }
+      }
+      return { value: JSON.parse(res.stdout) as T }
+    } catch (e) {
+      return {
+        health: {
+          result: 'failure' as const,
+          message: i18n('Could not read ${cmd} from Bitcoin: ${error}', {
+            cmd: cmd[0],
+            error: String(e),
+          }),
+        },
+      }
+    }
+  }
 
   /**
    * ======================== Daemons ========================
@@ -218,24 +288,10 @@ export const main = sdk.setupMain(async ({ effects }) => {
           failure: 5_000,
         }),
         fn: async () => {
-          const res = await bitcoindSub.exec([
-            ...bitcoinCliArgs({ prune: !!bitcoinConf.prune }),
-            '-rpcconnect=127.0.0.1',
-            'getblockchaininfo',
-          ])
+          const res = await probe<GetBlockchainInfo>('getblockchaininfo')
+          if ('health' in res) return res.health
 
-          if (
-            res.exitCode !== 0 ||
-            typeof res.stdout !== 'string' ||
-            res.stdout === ''
-          ) {
-            return {
-              message: i18n('Bitcoin is starting…'),
-              result: 'starting',
-            }
-          }
-
-          const info: GetBlockchainInfo = JSON.parse(res.stdout)
+          const info = res.value
           const syncing = {
             message: i18n('Syncing blocks...${percentage}%', {
               percentage: (info.verificationprogress * 100).toFixed(2),
@@ -249,21 +305,23 @@ export const main = sdk.setupMain(async ({ effects }) => {
 
           if (!info.initialblockdownload) return synced
 
-          // At genesis no headers have arrived, so nothing sits above the tip
-          // to find yet either.
-          if (info.blocks === 0) return syncing
+          // At genesis nothing sits above the tip to find yet either, and
+          // verificationprogress is still 0 — the header chain is the only
+          // thing moving.
+          if (info.blocks === 0)
+            return {
+              result: 'loading' as const,
+              message: info.headers
+                ? i18n('Syncing block headers: ${count}', {
+                    count: info.headers,
+                  })
+                : i18n('Syncing block headers…'),
+            }
 
-          const tipsRes = await bitcoindSub.exec([
-            ...bitcoinCliArgs({ prune: !!bitcoinConf.prune }),
-            '-rpcconnect=127.0.0.1',
-            'getchaintips',
-          ])
-          const tips: ChainTip[] =
-            tipsRes.exitCode === 0 &&
-            typeof tipsRes.stdout === 'string' &&
-            tipsRes.stdout !== ''
-              ? JSON.parse(tipsRes.stdout)
-              : []
+          // A tip list that cannot be read leaves `active` unset, which reads
+          // as syncing — the safe direction for a progress meter.
+          const tipsRes = await probe<ChainTip[]>('getchaintips')
+          const tips = 'value' in tipsRes ? tipsRes.value : []
           const active = tips.find((t) => t.status === 'active')
 
           return !active ||
@@ -309,6 +367,66 @@ export const main = sdk.setupMain(async ({ effects }) => {
       requires: ['sync-progress'],
     })
     /**
+     * Secondary indexes are built by a background thread that sync-progress
+     * cannot see: enabling one on an already-synced node starts a backfill
+     * from genesis, during which the RPCs it serves (getrawtransaction,
+     * getblockfilter, gettxoutsetinfo) answer for only part of the chain.
+     */
+    .addHealthCheck('index-sync', {
+      ready: {
+        display: i18n('Index Sync'),
+        trigger: sdk.trigger.statusTrigger(30_000, {
+          starting: 5_000,
+          failure: 5_000,
+        }),
+        fn: async () => {
+          // Keyed by bitcoind's own name for each index; only the enabled
+          // ones are listed, so an empty object means none are.
+          const res =
+            await probe<
+              Record<string, { synced: boolean; best_block_height: number }>
+            >('getindexinfo')
+          if ('health' in res) return res.health
+
+          const entries = Object.entries(res.value)
+
+          if (!entries.length)
+            return {
+              result: 'disabled' as const,
+              message: i18n('No indexes are enabled'),
+            }
+
+          // Report the furthest behind; as each finishes the next takes over.
+          const behind = entries
+            .filter(([, index]) => !index.synced)
+            .sort((a, b) => a[1].best_block_height - b[1].best_block_height)[0]
+
+          if (!behind)
+            return {
+              result: 'success' as const,
+              message: i18n('All enabled indexes are up to date'),
+            }
+
+          const tipRes = await probe<GetBlockchainInfo>('getblockchaininfo')
+          if ('health' in tipRes) return tipRes.health
+
+          const tip = tipRes.value.blocks
+
+          return {
+            result: 'loading' as const,
+            message: i18n('Building ${index}: ${percentage}%', {
+              index: indexLabel(behind[0]),
+              percentage: (tip
+                ? (behind[1].best_block_height / tip) * 100
+                : 0
+              ).toFixed(2),
+            }),
+          }
+        },
+      },
+      requires: ['bitcoind'],
+    })
+    /**
      * Chain-split recovery (see forkRecovery.ts). Consumes the store flag
      * set by cross-flavor migrations. This flavor never enforces RDTS
      * (BIP-110), so only the "leaving the enforcing flavor" half applies:
@@ -322,8 +440,11 @@ export const main = sdk.setupMain(async ({ effects }) => {
     .addOneshot('chain-recovery', {
       subcontainer: null,
       exec: {
-        fn: async () => {
+        fn: async (_, abortSignal) => {
           const prune = !!bitcoinConf.prune
+          // The bound on every bitcoin-cli call below (see forkRecovery.ts).
+          const abort = new AbortController()
+          abortSignal.addEventListener('abort', () => abort.abort())
 
           // Materialize an enforcement-regime transition into the durable
           // recovery flag BEFORE updating the marker, so a crash between
@@ -347,7 +468,10 @@ export const main = sdk.setupMain(async ({ effects }) => {
 
           if (wantReconsider) {
             try {
-              const res = await reconsiderInvalidTips(bitcoindSub, { prune })
+              const res = await reconsiderInvalidTips(bitcoindSub, {
+                prune,
+                abort,
+              })
               store.reconsiderInvalidTips = false
               await storeJson.merge(effects, {
                 reconsiderInvalidTips: false,
@@ -373,6 +497,12 @@ export const main = sdk.setupMain(async ({ effects }) => {
                 })
               }
             } catch (e) {
+              // A stop mid-reorg leaves the flag set and retries next start;
+              // that is not a failure to tell the user about.
+              if (abortSignal.aborted) {
+                console.warn('chain-recovery: interrupted by shutdown', e)
+                return null
+              }
               console.error('chain-recovery: reconsider failed', e)
               await sdk.notification.create(effects, {
                 level: 'error',


### PR DESCRIPTION
Three things a node operator could not see, and one false alarm.

## `index-sync` — a health check for the secondary indexes

`sync-progress` watches the chain, and nothing watches the indexes. Enabling txindex, the coinstats index, or block filters on a node that is **already synced** starts a backfill from the first block, and until it finishes `getrawtransaction`, `getblockfilter`, and `gettxoutsetinfo` answer for only the part of the chain the index has reached — while the UI reports the node fully synced. That is the case this check exists for; it is also why a dependent can look broken on a healthy node.

One check rather than one per index, because `getindexinfo` is already generic: it returns exactly the indexes bitcoind has enabled, keyed by its own name for each, so nothing has to be wired per-setting and a fourth index would be covered on arrival.

| State | Result | Message |
| --- | --- | --- |
| no index enabled (`{}`) | `disabled` | No indexes are enabled |
| every index at the tip | `success` | All enabled indexes are up to date |
| one or more behind | `loading` | Building _&lt;furthest behind&gt;_: _n_% |

Conditional on configuration through `disabled` rather than conditional registration, so the health-check set does not change shape when a setting is toggled. `success` throughout IBD is correct and not a lie: an index follows block connection rather than trailing it, so it sits at the tip the whole way down. It costs one RPC per poll — `getblockchaininfo` is fetched only while something is actually behind — and it cannot fail, because an index that is behind is working, not broken.

Verified against real `bitcoin-cli` on both the oldest and newest lines (28.3 and 31.0): `{}` with no index enabled, and `txindex` / `coinstatsindex` / `basic block filter index` with `synced` and `best_block_height` when all three are on.

## `sync-progress` says what bitcoind is actually doing

Every RPC failure collapsed to "Bitcoin is starting…", RPC warmup included — which is where a node spends the minutes it takes to load the block index, and the far longer stretch replaying blocks after an unclean stop. Indistinguishable from a hang, and the direct cause of more than one "is it stuck?" report.

`bitcoin-cli` renders an RPC error as `error code: <n>` / `error message:` / the message and exits `|n|`, so exit 28 (`RPC_IN_WARMUP`) now carries bitcoind's own account of the step it is on — `Verifying blocks…`, `Replaying blocks…`, `Loading P2P addresses…`. Anything else, a refused connection included, falls back to the old message unchanged; a refused connection exits 1, not 28, so the two cannot be confused. Both verified by running the real binary.

Below the first connected block, `verificationprogress` is 0 and the meter sat at `0.00%` for the whole header-sync phase. That phase now reports the header height instead, which is the only thing moving.

## The chain-recovery oneshot stops crying wolf

`forkRecovery.ts`'s `cli()` passes `-rpcwait -rpcclienttimeout=0` so the client never gives up — but `SubContainer.exec` SIGKILLs at 30 s by default, which is neither long enough for RPC warmup nor for a `reconsiderblock` that reorgs synchronously. The kill arrives as `exitCode: null`, and `exitCode !== 0` reported it as an RPC failure.

Seen on a live flavor switch in both directions: `getdeploymentinfo failed (null)` during the ~65 s RDTS re-validation, and `reconsiderblock failed (null)` on the way back to Core — the latter raising a **Chain Recovery Failed** notification for a reorg that had in fact completed, while leaving `reconsiderInvalidTips` set.

The exec now runs with no SDK deadline and takes the oneshot's `AbortSignal` instead, so the bound is service shutdown rather than an arbitrary 30 s. A signal-kill is reported as a kill rather than an RPC failure, and a stop mid-reorg logs and retries at the next start instead of notifying.

## Also

- `README.md` § Health Checks: the new check, the revised `sync-progress` behaviour, and the count.
- `instructions.md`: enabling an index after the chain is synced rebuilds from the first block, and what that means for anything depending on it.
- Eight new strings, translated across all five languages.

Part of #82
Part of #30
Part of Start9Labs/bitcoin-knots-startos#48
